### PR TITLE
Fix for `Py_buffer` and `match_data` memory leaks

### DIFF
--- a/src/pcre2/match.pyx
+++ b/src/pcre2/match.pyx
@@ -4,7 +4,6 @@
 from enum import IntEnum
 from libc.stdint cimport uint32_t
 from libc.stdlib cimport malloc, free
-from cpython cimport PyBuffer_Release
 from cpython.unicode cimport PyUnicode_Check
 cimport cython
 
@@ -48,7 +47,7 @@ cdef class Match:
 
     def __dealloc__(self):
         if self._subj is not NULL:
-            PyBuffer_Release(self._subj)
+            free_buffer(self._subj)
         if self._mtch is not NULL:
             pcre2_match_data_free(self._mtch)
 
@@ -118,7 +117,7 @@ cdef class Match:
             grp_num = (first_entry[0] << 8) | first_entry[1]
             if grp_num < 0:
                 raise_from_rc(grp_num, None)
-            PyBuffer_Release(grp_name)
+            free_buffer(grp_name)
 
         if grp_num > <int>ovec_count:
             raise ValueError("Group referenced out of bounds")
@@ -151,7 +150,7 @@ cdef class Match:
             grp_num = (first_entry[0] << 8) | first_entry[1]
             if grp_num < 0:
                 raise_from_rc(grp_num, None)
-            PyBuffer_Release(grp_name)
+            free_buffer(grp_name)
 
         if grp_num > <int>ovec_count:
             raise ValueError("Group referenced out of bounds.")
@@ -182,7 +181,7 @@ cdef class Match:
             )
             if get_rc < 0:
                 raise_from_rc(get_rc, None)
-            PyBuffer_Release(grp_name)
+            free_buffer(grp_name)
 
         # Clean up result and convert to unicode as appropriate.
         result = (<pcre2_sptr_t>res)[:res_len]
@@ -236,7 +235,7 @@ cdef class Match:
             result = result.decode("utf-8")
         
         free(res)
-        PyBuffer_Release(repl)
+        free_buffer(repl)
         return result
 
     def groups(self):

--- a/src/pcre2/pattern.pyx
+++ b/src/pcre2/pattern.pyx
@@ -339,7 +339,8 @@ cdef class Pattern:
             subj_type = "string" if is_subj_utf else "bytes-like"
             raise ValueError(f"Cannot use a {patn_type} pattern with a {subj_type} subject")
 
-        return Scanner._from_data(self, subject, offset)
+        subj = get_buffer(subject)
+        return Scanner._from_data(self, subj, offset)
 
 
     def split(self, subject, maxsplit=0, offset=0):

--- a/src/pcre2/pattern.pyx
+++ b/src/pcre2/pattern.pyx
@@ -3,7 +3,7 @@
 # Standard libraries.
 from libc.stdint cimport uint32_t
 from libc.stdlib cimport malloc, free
-from cpython cimport Py_buffer, PyBuffer_Release
+from cpython cimport Py_buffer
 from cpython cimport array
 from cpython.unicode cimport PyUnicode_Check
 from cpython.memoryview cimport PyMemoryView_FromMemory
@@ -62,7 +62,7 @@ cdef class Pattern:
 
     def __dealloc__(self):
         if self._patn is not NULL:
-            PyBuffer_Release(self._patn)
+            free_buffer(self._patn)
         if self._code is not NULL:
             pcre2_code_free(self._code)
 
@@ -413,8 +413,8 @@ cdef class Pattern:
         # Capture return codes from both substitute attempts.
         if substitute_rc < 0:
             free(res)
-            PyBuffer_Release(subj)
-            PyBuffer_Release(repl)
+            free_buffer(subj)
+            free_buffer(repl)
             rc[0] = substitute_rc
             return NULL, 0
         
@@ -467,6 +467,6 @@ cdef class Pattern:
             result = result.decode("utf-8")
         
         free(res)
-        PyBuffer_Release(subj)
-        PyBuffer_Release(repl)
+        free_buffer(subj)
+        free_buffer(repl)
         return result

--- a/src/pcre2/scanner.pxd
+++ b/src/pcre2/scanner.pxd
@@ -11,7 +11,7 @@ from .pattern cimport Pattern
 
 cdef class Scanner:
     cdef Pattern _pattern
-    cdef object _subject
+    cdef Py_buffer *_subj
 
     cdef bint _is_crlf_newline
     cdef bint _is_patn_utf
@@ -22,5 +22,5 @@ cdef class Scanner:
 
     @staticmethod
     cdef Scanner _from_data(
-        Pattern pattern, object subject, size_t offset
+        Pattern pattern, Py_buffer *subject, size_t offset
     )

--- a/src/pcre2/scanner.pyx
+++ b/src/pcre2/scanner.pyx
@@ -3,7 +3,7 @@
 # Standard libraries.
 from libc.stdint cimport uint32_t
 from libc.stdlib cimport malloc, free
-from cpython cimport Py_buffer, PyBuffer_Release
+from cpython cimport Py_buffer
 from cpython cimport array
 from cpython.unicode cimport PyUnicode_Check
 from cpython.memoryview cimport PyMemoryView_FromMemory

--- a/src/pcre2/scanner.pyx
+++ b/src/pcre2/scanner.pyx
@@ -171,5 +171,3 @@ cdef class Scanner:
             return Match._from_data(
                 mtch, self._pattern, subj_copy, self._state_ofst, self._state_opts
             )
-        
-        pcre2_match_data_free(mtch)

--- a/src/pcre2/scanner.pyx
+++ b/src/pcre2/scanner.pyx
@@ -84,6 +84,7 @@ cdef class Scanner:
             ofst, obj_ofst = codepoint_to_codeunit(subj, offset, 0, 0)
             scanner._state_ofst = ofst
             scanner._state_obj_ofst = obj_ofst
+            free_buffer(subj)
         else:
             scanner._state_obj_ofst = offset
             scanner._state_ofst = scanner._state_obj_ofst
@@ -116,7 +117,7 @@ cdef class Scanner:
             # Default match is not achored so if no match found at current offset, then there
             # will not be any ahead either.
             if self._state_opts == 0:
-                PyBuffer_Release(subj)
+                free_buffer(subj)
                 raise StopIteration
 
             # Reset options so empty strings can match at next offset.

--- a/src/pcre2/utils.pxd
+++ b/src/pcre2/utils.pxd
@@ -4,6 +4,8 @@
 from cpython cimport Py_buffer
 
 
+cdef int free_buffer(Py_buffer *pybuf)
+
 cdef Py_buffer * get_buffer(object obj) except NULL
 
 cdef (size_t, size_t) codeunit_to_codepoint(


### PR DESCRIPTION
This PR addresses issue #5 raised by @vkargov, fixing two instances of memory leaks - the first on released `Py_buffer` pointers, and the second on `match_data` blocks allocated during pattern scanning. The `Scanner` object has also been updated to use a `Py_buffer` subject for consistency in ownership across objects