### PR TITLE
Fix for match group unset errors and usability improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ src/pcre2/**/*.html
 
 .pytest_cache
 Profile.prof
+
+scratch

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ Substitution is also supported, both from `Pattern` and `Match` objects,
 
 ```python
 >>> repl = '$2 $1'
->>> patn.substitute(repl, subj)
-'bar foo buzz bazz'
->>> patn.substitute(repl, subj, options=pcre2.G) # Global substitutions are also supported.
+>>> patn.substitute(repl, subj) # Global substitutions by default.
 'bar foo bazz buzz'
+>>> patn.substitute(repl, subj, suball=False)
+'bar foo buzz bazz'
 >>> match.expand(repl)
 'bar foo buzz bazz'
 ```

--- a/benchmarks/regex_redux/pcre2_module.py
+++ b/benchmarks/regex_redux/pcre2_module.py
@@ -8,8 +8,6 @@ import sys
 import pcre2
 import multiprocessing as mp
 
-GLOBAL = pcre2.SubstituteOption.GLOBAL
-
 
 def init_pool(_data):
     # Pool initializer
@@ -29,7 +27,7 @@ def seq_subs(data, subs, result):
     # Apply sequential substitions to given data and store in multiprocess
     # manager value.
     for patn, repl in subs:
-        data = pcre2.substitute(patn, repl, data, options=GLOBAL)
+        data = pcre2.substitute(patn, repl, data)
     result.value = data
 
 
@@ -37,7 +35,7 @@ def main():
     data = sys.stdin.buffer.read()
     init_len = len(data)
 
-    data = pcre2.substitute(b">.*\n|\n", b"", data, options=GLOBAL)
+    data = pcre2.substitute(b">.*\n|\n", b"", data)
     clean_len = len(data)
 
     patns = (

--- a/src/pcre2/__init__.py
+++ b/src/pcre2/__init__.py
@@ -1,7 +1,7 @@
 from .methods import compile, findall, match, scan, split, substitute
 from .consts import (
     __libpcre2_version__,
-    CompileOption, MatchOption, SubstituteOption, ExpandOption,
-    A, I, G, M, NE, NS, U, S, X
+    CompileOption,
+    A, I, M, U, S, X
 )
 __version__ = "0.3.0"

--- a/src/pcre2/consts.pyx
+++ b/src/pcre2/consts.pyx
@@ -62,38 +62,6 @@ class CompileOption(MetaOption):
     UTF = PCRE2_UTF
 
 
-class MatchOption(MetaOption):
-    """ Option bits to be used when matching. See the following PCRE2
-    documentation for a brief overview of the relevant options:
-    http://pcre.org/current/doc/html/pcre2_match.html
-    """
-    NOTBOL = PCRE2_NOTBOL
-    NOTEOL = PCRE2_NOTEOL
-    NOTEMPTY = PCRE2_NOTEMPTY
-    NOTEMPTY_ATSTART = PCRE2_NOTEMPTY_ATSTART
-
-
-class SubstituteOption(MetaOption):
-    """ Option bits to be used when making pattern substitutions. See the
-    following PCRE2 documentation for a brief overview of the relevant
-    options:
-    http://pcre.org/current/doc/html/pcre2_substitute.html
-    """
-    NOTBOL = PCRE2_NOTBOL
-    NOTEOL = PCRE2_NOTEOL
-    NOTEMPTY = PCRE2_NOTEMPTY
-    NOTEMPTY_ATSTART = PCRE2_NOTEMPTY_ATSTART
-    GLOBAL = PCRE2_SUBSTITUTE_GLOBAL
-    EXTENDED = PCRE2_SUBSTITUTE_EXTENDED
-    UNSET_EMPTY = PCRE2_SUBSTITUTE_UNSET_EMPTY
-    UNKNOWN_UNSET = PCRE2_SUBSTITUTE_UNKNOWN_UNSET
-    LITERAL = PCRE2_SUBSTITUTE_LITERAL
-    REPLACEMENT_ONLY = PCRE2_SUBSTITUTE_REPLACEMENT_ONLY
-
-# Type alias.
-ExpandOption = SubstituteOption
-
-
 class BsrChar(IntEnum):
     """ Indicator for what character(s) are denoted by `\r`.
     """
@@ -115,10 +83,7 @@ class NewlineChar(IntEnum):
 # Shorthands
 A = CompileOption.ANCHORED
 I = CompileOption.CASELESS
-G = SubstituteOption.GLOBAL
 M = CompileOption.MULTILINE
-NE = MatchOption.NOTEMPTY
-NS = MatchOption.NOTEMPTY_ATSTART
 U = CompileOption.UTF
 S = CompileOption.DOTALL
 X = CompileOption.EXTENDED

--- a/src/pcre2/libpcre2.pxd
+++ b/src/pcre2/libpcre2.pxd
@@ -443,10 +443,22 @@ cdef extern from "pcre2.h":
     )
 
     # String extraction from match data blocks.
+    int pcre2_substring_length_byname(
+        pcre2_match_data_t *match_data,
+        pcre2_sptr_t name,
+        size_t *bufflen
+    )
+
     int pcre2_substring_get_byname(
         pcre2_match_data_t *match_data,
         pcre2_sptr_t name, 
         uint8_t **bufferptr,
+        size_t *bufflen
+    )
+
+    int pcre2_substring_length_bynumber(
+        pcre2_match_data_t *match_data,
+        uint32_t number,
         size_t *bufflen
     )
 

--- a/src/pcre2/methods.pyx
+++ b/src/pcre2/methods.pyx
@@ -45,39 +45,50 @@ def compile(pattern, options=0, jit=False):
     return pattern_obj
 
 
-def findall(pattern, subject, offset=0):
+def findall(pattern, subject, offset=0, options=0, jit=True):
     """ Shorthand for compiling a pattern, then calling findall. Note that this
     will use JIT compilation.
     """
-    return compile(pattern, jit=True).findall(subject, offset=offset)
+    return compile(pattern, options=options, jit=jit).findall(subject, offset=offset)
 
 
-def match(pattern, subject, offset=0, options=0):
+def match(pattern, subject, offset=0, options=0, jit=False):
     """ Shorthand for compiling a pattern, then calling match.
     """
-    return compile(pattern).match(subject, offset=offset, options=options)
+    return compile(pattern, options=options, jit=jit).match(subject, offset=offset)
 
 
-def scan(pattern, subject, offset=0):
+def scan(pattern, subject, offset=0, options=0, jit=True):
     """ Shorthand for compiling a pattern, then calling scan. Note that this
     will use JIT compilation.
     """
-    return compile(pattern, jit=True).scan(subject, offset=offset)
+    return compile(pattern, options=options, jit=jit).scan(subject, offset=offset)
 
 
-def split(pattern, subject, maxsplit=0, offset=0):
+def split(pattern, subject, maxsplit=0, offset=0, options=0, jit=True):
     """ Shorthand for compiling a pattern, then calling split. Note that this
     will use JIT compilation.
     """
-    return compile(pattern, jit=True).split(subject, maxsplit=maxsplit, offset=offset)
+    pattern_obj = compile(pattern, options=options, jit=jit)
+    return pattern_obj.split(subject, maxsplit=maxsplit, offset=offset)
 
 
-def substitute(pattern, replacement, subject, offset=0, options=0, low_memory=False):
+def substitute(
+    pattern,
+    replacement,
+    subject,
+    offset=0,
+    suball=True,
+    literal=False,
+    low_memory=False,
+    options=0,
+    jit=True
+):
     """ Shorthand for compiling a pattern, then calling substitute.
     """
-    pattern_obj = compile(pattern)
-    if <int>options & PCRE2_SUBSTITUTE_GLOBAL:
+    pattern_obj = compile(pattern, options=options, jit=jit)
+    if suball:
         pattern_obj.jit_compile()
     return pattern_obj.substitute(
-        replacement, subject, offset=offset, options=options, low_memory=low_memory
+        replacement, subject, offset=offset, suball=suball, literal=literal, low_memory=low_memory
     )

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,7 +1,6 @@
 import pytest
 import pcre2
 from pcre2.exceptions import CompileError, MatchError, LibraryError
-from pcre2.consts import CompileOption, MatchOption, SubstituteOption
 
 def test_match_groups():
     assert pcre2.match('a', 'a').groups() == ()

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,7 +1,6 @@
 import pytest
 import pcre2
 from pcre2.exceptions import CompileError, MatchError, LibraryError
-from pcre2.consts import CompileOption, MatchOption, SubstituteOption
 
 
 # All tests should match successfully.
@@ -11,8 +10,8 @@ test_data_match_bounds = [
 ]
 @pytest.mark.parametrize("pattern,subject,options,offset,group,start,end", test_data_match_bounds)
 def test_match_bounds(pattern, subject, options, offset, group, start, end):
-    p = pcre2.compile(pattern)
-    m = p.match(subject, options=options, offset=offset)
+    p = pcre2.compile(pattern, options=options)
+    m = p.match(subject, offset=offset)
     assert (m.start(group), m.end(group)) == (start, end)
 
 
@@ -22,8 +21,8 @@ test_data_match_substring = [
 ]
 @pytest.mark.parametrize("pattern,subject,options,offset,substring", test_data_match_substring)
 def test_match_substring(pattern, subject, options, offset, substring):
-    p = pcre2.compile(pattern)
-    m = p.match(subject, options=options, offset=offset)
+    p = pcre2.compile(pattern, options=options)
+    m = p.match(subject, offset=offset)
     assert m.substring() == substring
 
 
@@ -36,6 +35,6 @@ test_data_match_expand = [
     "pattern,replacement,subject,options,offset,result", test_data_match_expand
 )
 def test_match_expand(pattern, replacement, subject, options, offset, result):
-    p = pcre2.compile(pattern)
-    m = p.match(subject, options=options, offset=offset)
+    p = pcre2.compile(pattern, options=options)
+    m = p.match(subject, offset=offset)
     assert m.expand(replacement) == result

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -1,7 +1,7 @@
 import pytest
 import pcre2
 from pcre2.exceptions import CompileError, MatchError, LibraryError
-from pcre2.consts import CompileOption, MatchOption, SubstituteOption
+from pcre2.consts import CompileOption
 
 
 test_data_pattern_compile_success = [
@@ -69,9 +69,9 @@ test_data_pattern_match_success = [
     "pattern,subject,options,offset,return_code", test_data_pattern_match_success
 )
 def test_pattern_match_success(pattern, subject, options, offset, return_code):
-    p = pcre2.compile(pattern)
+    p = pcre2.compile(pattern, options=options)
     try:
-        m = p.match(subject, options=options, offset=offset)
+        m = p.match(subject, offset=offset)
         rc = "SUCCESS"
     except MatchError as e:
         rc = "MATCH_ERROR"
@@ -101,18 +101,18 @@ def test_pattern_scan_length(pattern, subject, offset, iter_length):
 
 
 test_pattern_substitute = [
-    (b"[abc]*", b"", b"dabacbaccbacccb", 0, 0, b"dabacbaccbacccb"),
-    ("[abc]*", "", "dabacbaccbacccb", 0, 0, "dabacbaccbacccb"),
-    ("[abc]*", "", "dabacbaccbacccb", 0, 1, "d"),
-    ("a(•{2,})b", "a•b", "aba•ba••ba•••b", SubstituteOption.GLOBAL, 0, "aba•ba•ba•b"),
-    ("a(•{2,})b", "a•b", "aba•ba••ba•••b", SubstituteOption.GLOBAL | SubstituteOption.REPLACEMENT_ONLY, 0, "a•ba•b"),
+    (b"[abc]*", b"", b"dabacbaccbacccb", False, False, 0, b"dabacbaccbacccb"),
+    ("[abc]*", "", "dabacbaccbacccb", False, False, 0, "dabacbaccbacccb"),
+    ("[abc]*", "", "dabacbaccbacccb", False, False, 1, "d"),
+    ("a(•{2,})b", "a•b", "aba•ba••ba•••b", True, False, 0, "aba•ba•ba•b"),
+    ("a(•{2,})b", "a$1b", "aba•ba••ba•••b", True, True, 0, "aba•ba$1ba$1b"),
 ]
 @pytest.mark.parametrize(
-    "pattern,replacement,subject,options,offset,result", test_pattern_substitute
+    "pattern,replacement,subject,suball,literal,offset,result", test_pattern_substitute
 )
-def test_pattern_substitute(pattern, replacement, subject, options, offset, result):
+def test_pattern_substitute(pattern, replacement, subject, suball, literal, offset, result):
     p = pcre2.compile(pattern)
-    assert p.substitute(replacement, subject, options=options, offset=offset) == result
+    assert p.substitute(replacement, subject, suball=suball, literal=literal, offset=offset) == result
 
 def test_pattern_findall():
     p = pcre2.compile(r'(\w+)=(\d+)')


### PR DESCRIPTION
This PR addresses issues raised in #3, as well as addresses general ergonomics. Namely, errors thrown on unset match groups have been resolved, and uses a default value in line with Python's `re` library. Other changes to improve usability include:
* Defaulting substitutions to be global
* Removing match and substitution options in favor keyword argument flags