### PR TITLE
Add support for partial matches

### DIFF
--- a/src/pcre2/__init__.py
+++ b/src/pcre2/__init__.py
@@ -296,6 +296,10 @@ class Match:
         self.pos = pos
         self.endpos = endpos
 
+    @property
+    def is_partial(self):
+        return self._pcre2_match_data.is_partial
+
     def expand(self, template):
         """
         Return the string obtained by substitution on the template string `template`.

--- a/src/pcre2/_cy.pyx
+++ b/src/pcre2/_cy.pyx
@@ -43,13 +43,15 @@ cdef class PCRE2Code:
 
 cdef class PCRE2MatchData:
     cdef pcre2_match_data_t *ptr
+    cdef public bint is_partial
 
     @staticmethod
-    cdef PCRE2MatchData from_ptr(pcre2_match_data_t *ptr):
+    cdef PCRE2MatchData from_ptr(pcre2_match_data_t *ptr, bint is_partial):
         """ Ownership of pointer is always taken by the new instance """
         cdef PCRE2MatchData match_data
         match_data = PCRE2MatchData.__new__(PCRE2MatchData)
         match_data.ptr = ptr
+        match_data.is_partial = is_partial
         return match_data
 
     def __init__(self, *args, **kwargs):
@@ -281,6 +283,8 @@ class MatchOption(IntEnum):
     ENDANCHORED = PCRE2_ENDANCHORED
     NOTEMPTY = PCRE2_NOTEMPTY
     NOTEMPTY_ATSTART = PCRE2_NOTEMPTY_ATSTART
+    PARTIAL_SOFT = PCRE2_PARTIAL_SOFT
+    PARTIAL_HARD = PCRE2_PARTIAL_HARD
 
 cdef pcre2_match_data_t * _pcre2_match_data_create_from_pattern(
     const pcre2_code_t *code, pcre2_general_context_t *gcontext
@@ -323,9 +327,10 @@ cdef PCRE2MatchData _match(
     rc = _pcre2_match(code.ptr, subj_sptr, byte_length, byte_offset, options, match_data_ptr, NULL)
     if rc == PCRE2_ERROR_NOMATCH:
         return None
-    raise_from_rc(rc)
+    elif rc != PCRE2_ERROR_PARTIAL:
+        raise_from_rc(rc)
 
-    return PCRE2MatchData.from_ptr(match_data_ptr)
+    return PCRE2MatchData.from_ptr(match_data_ptr, rc == PCRE2_ERROR_PARTIAL)
 
 def match(
     PCRE2Code code not None,


### PR DESCRIPTION
This PR adds partial support for partial matches, ho ho.

It adds an `is_partial` property to the Match class, and when the return code from a match attempt is `PCRE2_ERROR_PARTIAL`, returns the match with this flag set, rather than raising an error.

So far, so good.

What is missing is that the bindings currently have no way to pass run-time options to a match routine. Hence, it’s currently necessary to call the hidden `_match` method to use this functionality.
