### PR TITLE
Add arm64 windows support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 
 on:
   push:
-    branches: [main, arm64-runner]
+    branches: [main]
   pull_request:
     branches: [main]
   release:


### PR DESCRIPTION
Closes #21 

This would add windows arm64 wheel builds to the `build.yml` workflow.