### PR TITLE
Pin OS build versions + speed up Linux aarch64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         include:
           - name: Windows AMD64
-            os: windows-latest
+            os: windows-2025
             platform: amd64
             build: cp*-win_amd64
           - name: Windows ARM64
@@ -59,21 +59,21 @@ jobs:
             platform: arm64
             build: cp*-win_arm64
           - name: macOS x86-64
-            os: macos-latest
+            os: macos-15-intel
             platform: x86_64
             build: "cp*-macosx_x86_64"
           - name: macOS ARM64
-            os: macos-latest
+            os: macos-15
             platform: arm64
             build: "cp*-macosx_arm64"
           - name: Ubuntu x86-64
-            os: ubuntu-latest
+            os: ubuntu-24.04
             platform: x86_64
             build: "cp*-manylinux_x86_64"
           - name: Ubuntu x86-64 with MUSL
-            os: ubuntu-latest
-            build: "cp*-musllinux_x86_64"
+            os: ubuntu-24.04
             platform: x86_64_musl
+            build: "cp*-musllinux_x86_64"
           - name: Ubuntu Aarch64
             os: ubuntu-24.04-arm
             platform: aarch64


### PR DESCRIPTION
Move away from `*-latest` build platforms to fully qualified OS versions. This additionally moves the Linux aarch64 build to `ubuntu-24.04-arm`, obviating the need for costly QEMU emulation