### PR TITLE
Add support for PCRE2 callouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ profile.html
 profile.json
 
 scratch
+
+scalene-profile.html
+scalene-profile.json

--- a/README.md
+++ b/README.md
@@ -85,6 +85,27 @@ foo
 buzz
 ```
 
+Callout functions may be provided and will be called during matching whenever a `(?C<arg>)` is
+encountered.
+Callouts can control whether a match continues without impact, fails and begins looking for the
+next match, or aborts the matching job entirely.
+Functions are expected to take a `CalloutBlock` and return a `CalloutReturn`, e.g.,
+```python
+>>> def callout(callout_block: CalloutBlock):
+...     print(callout_block.value + callout_block[0])
+...     return CalloutReturn.PASS
+...
+>>> pcre2.search(r"\w+(?C'temp: ')(*FAIL)", "abc", flags=pcre2.O0, callout=callout)
+temp: abc
+temp: ab
+temp: a
+temp: bc
+temp: b
+temp: c
+```
+
+For a more in depth discussion on PCRE2 callouts - and on this particular use of callouts - read [this post from Rex Egg](https://www.rexegg.com/pcre-callouts.php).
+
 ## Performance
 
 PCRE2 provides a fast regular expression library, particularly with JIT compilation enabled.
@@ -92,11 +113,11 @@ Below are the `regex-redux` benchmark results included in this repository,
 
 | Script              | Number of runs | Total time | Real time  | User time   | System time   |
 | ------------------- | -------------- | ---------- | ---------- | ----------- | ------------- |
-| baseline.py         |             10 |      3.230 |      0.323 |       0.020 |         0.100 |
-| re_vanilla.py       |             10 |     51.090 |      5.109 |      11.375 |         0.530 |
-| pcre2_vanilla.py    |             10 |     21.980 |      2.198 |       3.154 |         0.483 |
-| pcre2_optimized.py  |             10 |     14.860 |      1.486 |       2.520 |         0.548 |
-| cffi_optimized.py   |             10 |     14.130 |      1.413 |       3.111 |         0.411 |
+| baseline.py         |             10 |      3.000 |      0.300 |       0.020 |         0.110 |
+| re_vanilla.py       |             10 |     49.650 |      4.965 |      10.582 |         0.571 |
+| pcre2_vanilla.py    |             10 |     19.770 |      1.977 |       3.375 |         0.481 |
+| pcre2_optimized.py  |             10 |     14.960 |      1.496 |       3.546 |         0.590 |
+| cffi_optimized.py   |             10 |     13.350 |      1.335 |       3.930 |         0.381 |
  
 Script descriptions are as follows,
 

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -1,3 +1,4 @@
 twine
 pytest
 gitpython
+scalene

--- a/src/pcre2/__init__.py
+++ b/src/pcre2/__init__.py
@@ -1,9 +1,8 @@
 from . import _cy
 
-from enum import auto, IntFlag
-import operator
+from enum import auto, IntEnum, IntFlag
 from itertools import islice
-from functools import lru_cache, reduce
+from functools import lru_cache
 from types import MappingProxyType
 from sys import maxsize
 
@@ -18,6 +17,15 @@ __version__ = "0.6.0"
 __libpcre2_version__ = _cy.__libpcre2_version__
 
 
+_EMPTY_MATCH_CONTEXT = _cy.create_match_context()
+
+
+class CalloutReturn(IntEnum):
+    PASS = _cy.CalloutFunctionReturn.PASS
+    FAIL = _cy.CalloutFunctionReturn.FAIL
+    ABORT = _cy.CalloutFunctionReturn.ABORT
+
+
 class RegexFlag(IntFlag):
     # Flags either enable (True) or disable (False) PCRE2 options
     NOFLAG = 0
@@ -26,6 +34,11 @@ class RegexFlag(IntFlag):
     MULTILINE = _cy.CompileOption.MULTILINE  # Make anchors look for newline
     DOTALL = _cy.CompileOption.DOTALL  # Make dot match newline
     VERBOSE = _cy.CompileOption.EXTENDED  # Ignore whitespace and comments
+    NOOPT = (
+        _cy.CompileOption.NO_AUTO_POSSESS
+        | _cy.CompileOption.NO_START_OPTIMIZE
+        | _cy.CompileOption.NO_DOTSTAR_ANCHOR
+    )
 
     # No corresponding flag in PCRE2, but is the opposite of `_cy.CompileOption.UCP`
     ASCII = auto()  # ASCII-only matching for character classes
@@ -38,6 +51,7 @@ UNICODE = U = RegexFlag.UNICODE
 MULTILINE = M = RegexFlag.MULTILINE
 DOTALL = S = RegexFlag.DOTALL
 VERBOSE = X = RegexFlag.VERBOSE
+NOOPT = O0 = RegexFlag.NOOPT
 
 
 LibraryError = _cy.LibraryError
@@ -60,7 +74,7 @@ def _typeguard_strings(s):
 #                                                          Top-Level Functions
 
 
-def compile(pattern, flags=0, jit=True):
+def compile(pattern, flags=0, *, jit=True, callout=None):
     """
     Compile a regular expression pattern, returning a Pattern object.
     """
@@ -83,50 +97,50 @@ def compile(pattern, flags=0, jit=True):
     pcre2_code = _cy.compile(pattern, options, disabled_options)
     if jit:
         _cy.jit_compile(pcre2_code)
-    return Pattern(pcre2_code, pattern, flags, jit)
+    return Pattern(pcre2_code, pattern, flags, jit, callout)
 
 
-def search(pattern, string, flags=0, jit=True):
+def search(pattern, string, flags=0, *, jit=True, callout=None):
     """
     Scan through `string` looking for a match to the pattern, returning a Match object, or None if
     no match was found.
     """
-    return compile(pattern, flags, jit).search(string)
+    return compile(pattern, flags, jit=jit, callout=callout).search(string)
 
 
-def match(pattern, string, flags=0, jit=True):
+def match(pattern, string, flags=0, *, jit=True, callout=None):
     """
     Match the pattern at the start of `string`, returning a Match object, or None if no match was
     found.
     """
-    return compile(pattern, flags, jit).match(string)
+    return compile(pattern, flags, jit=jit, callout=callout).match(string)
 
 
-def fullmatch(pattern, string, flags=0, jit=True):
+def fullmatch(pattern, string, flags=0, *, jit=True, callout=None):
     """
     Match the pattern to all of `string`, returning a Match object, or None if no match was found.
     """
-    return compile(pattern, flags, jit).fullmatch(string)
+    return compile(pattern, flags, jit=jit, callout=callout).fullmatch(string)
 
 
-def finditer(pattern, string, flags=0, jit=True):
+def finditer(pattern, string, flags=0, *, jit=True, callout=None):
     """
     Return an iterator of Match objects for each non-overlapping match in the string.
     """
-    return compile(pattern, flags, jit).finditer(string)
+    return compile(pattern, flags, jit=jit, callout=callout).finditer(string)
 
 
-def findall(pattern, string, flags=0, jit=True):
+def findall(pattern, string, flags=0, *, jit=True, callout=None):
     """
     Return a list of all non-overlapping matches in `string`.
 
     If one or more capture groups are present, return a list of groups for each match. Empty
     matches are included in the result.
     """
-    return compile(pattern, flags, jit).findall(string)
+    return compile(pattern, flags, jit=jit, callout=callout).findall(string)
 
 
-def split(pattern, string, maxsplit=0, flags=0, jit=True):
+def split(pattern, string, maxsplit=0, flags=0, *, jit=True, callout=None):
     """
     Split the source string by the occurrences of the pattern, returning a list containing the
     resulting substrings.
@@ -135,10 +149,10 @@ def split(pattern, string, maxsplit=0, flags=0, jit=True):
     `maxsplit` is non-zero, at most `maxsplit` splits occur, and the remainder of `string` is
     returned as the final element of the list.
     """
-    return compile(pattern, flags, jit).split(string, maxsplit)
+    return compile(pattern, flags, jit=jit, callout=callout).split(string, maxsplit)
 
 
-def subn(pattern, repl, string, count=0, flags=0, jit=True):
+def subn(pattern, repl, string, count=0, flags=0, *, jit=True, callout=None):
     """
     Return a tuple containing `(res, number)`. `res` is the string obtained by replacing the
     leftmost non-overlapping occurrences of the pattern in `string` by the replacement `repl`.
@@ -147,10 +161,10 @@ def subn(pattern, repl, string, count=0, flags=0, jit=True):
     `repl` can be either a string or a callable. If it is a callable, it's passed the Match object
     and must return a replacement string to be used.
     """
-    return compile(pattern, flags, jit).subn(repl, string, count)
+    return compile(pattern, flags, jit=jit, callout=callout).subn(repl, string, count)
 
 
-def sub(pattern, repl, string, count=0, flags=0, jit=True):
+def sub(pattern, repl, string, count=0, flags=0, *, jit=True, callout=None):
     """
     Return the string obtained by replacing the leftmost non-overlapping occurrences of the pattern
     in `string` by the replacement `repl`.
@@ -158,7 +172,7 @@ def sub(pattern, repl, string, count=0, flags=0, jit=True):
     `repl` can be either a string or a callable. If it is a callable, it's passed the Match object
     and must return a replacement string to be used.
     """
-    return compile(pattern, flags, jit).sub(repl, string, count)
+    return compile(pattern, flags, jit=jit, callout=callout).sub(repl, string, count)
 
 
 # ============================================================================
@@ -166,7 +180,7 @@ def sub(pattern, repl, string, count=0, flags=0, jit=True):
 
 
 class Pattern:
-    def __init__(self, pcre2_code, pattern, flags, jit):
+    def __init__(self, pcre2_code, pattern, flags, jit, callout):
         if not isinstance(pcre2_code, _cy.PCRE2Code):
             raise ValueError(
                 "PCRE2 code must be of type `_cy.PCRE2Code`. It is not recommended to instantiate "
@@ -176,6 +190,7 @@ class Pattern:
         self.pattern = pattern
         self.flags = flags
         self.jit = jit
+        self.callout = callout
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -208,12 +223,28 @@ class Pattern:
             _cy.jit_compile(self._pcre2_code)
             self.jit = True
 
+    def _get_match_context(self, string):
+        # Wrap the callout function so userland only interacts with python object, not Cython
+        # extension type
+        if self.callout is None:
+            return _EMPTY_MATCH_CONTEXT
+        elif callable(self.callout):
+
+            def callout_wrapped(pcre2_callout_block):
+                callout_block = CalloutBlock(pcre2_callout_block, self, string)
+                return self.callout(callout_block)
+
+            match_context = _cy.create_match_context(callout_function=callout_wrapped)
+            return match_context
+        raise ValueError("Callout must either be unspecified or a callable")
+
     def _match(self, string, pos=0, endpos=maxsize, options=0):
         string = _typeguard_strings(string)
         pos = max(0, min(pos, len(string)))
         endpos = max(0, min(endpos, len(string)))
+        match_context = self._get_match_context(string)
         match_data, match_byte_offset, match_options = _cy.match(
-            self._pcre2_code, string, endpos, pos, options
+            self._pcre2_code, string, endpos, pos, match_context, options
         )
         if match_data:
             return Match(match_data, self, string, pos, endpos, match_byte_offset, match_options)
@@ -248,8 +279,9 @@ class Pattern:
         string = _typeguard_strings(string)
         pos = max(0, min(pos, len(string)))
         endpos = max(0, min(endpos, len(string)))
+        match_context = self._get_match_context(string)
         for match_data, match_byte_offset, match_options in _cy.match_generator(
-            self._pcre2_code, string, endpos, pos
+            self._pcre2_code, string, endpos, pos, match_context
         ):
             yield Match(match_data, self, string, pos, endpos, match_byte_offset, match_options)
 
@@ -315,7 +347,7 @@ class Pattern:
             return (string, 0)
 
         # Short circuit for global substitute
-        if count == 0 and not callable(repl):
+        if count == 0 and not callable(repl) and not self.callout:
             return self._suball(repl, string)
 
         parts = []
@@ -360,6 +392,8 @@ class Pattern:
 
 
 class Match:
+    __slots__ = ("_pcre2_match_data", "re", "string", "pos", "endpos", "_byte_offset", "_options")
+
     def __init__(self, pcre2_match_data, re, string, pos, endpos, byte_offset, options):
         if not isinstance(pcre2_match_data, _cy.PCRE2MatchData):
             raise ValueError(
@@ -420,11 +454,11 @@ class Match:
         If `group` did not contribute to the match, `(-1, -1)` is returned.
         """
         group_number = self._groupguard(group)
-        return _cy.substring_span_bynumber(self._pcre2_match_data, self.string, group_number)
+        return _cy.match_substring_span_bynumber(self._pcre2_match_data, self.string, group_number)
 
     def __getitem__(self, group):
         group_number = self._groupguard(group)
-        return _cy.substring_bynumber(self._pcre2_match_data, self.string, group_number)
+        return _cy.match_substring_bynumber(self._pcre2_match_data, self.string, group_number)
 
     def group(self, *groups):
         """
@@ -442,6 +476,135 @@ class Match:
     def groups(self, default=None):
         """
         Return a tuple containing all the subgroups of the match.
+        """
+        items = []
+        for group in range(1, self.re.groups + 1):
+            item = self.__getitem__(group)
+            items.append(default if item is None else item)
+        return tuple(items)
+
+    def groupdict(self, default=None):
+        """
+        Return a dictionary mapping subgroup name to group number for all the named subgroups.
+        """
+        items = []
+        for group, index in self.re.groupindex.items():
+            item = self.__getitem__(index)
+            items.append((group, default) if item is None else (group, item))
+        return dict(items)
+
+    def start(self, group=0):
+        """
+        Return the start index of the substring matched by `group`.
+        """
+        return self.span(group)[0]
+
+    def end(self, group=0):
+        """
+        Return the end index of the substring matched by `group`.
+        """
+        return self.span(group)[1]
+
+    @property
+    @lru_cache(1)
+    def lastindex(self):
+        max_end = -1
+        max_group = None
+        # We look for the rightmost right parenthesis by keeping the first group that ends at
+        # max_end because that is the leftmost/outermost group when there are nested groups!
+        for group in range(1, self.re.groups + 1):
+            end = self.end(group)
+            if max_end < end:
+                max_end = end
+                max_group = group
+        return max_group
+
+    @property
+    @lru_cache(1)
+    def lastgroup(self):
+        max_group = self.lastindex
+        if not max_group:
+            return None
+        for group, index in self.re.groupindex.items():
+            if max_group == index:
+                return group
+        return None
+
+
+# ============================================================================
+#                                                         Callout Block Object
+
+
+class CalloutBlock:
+    def __init__(self, pcre2_callout_block, re, string):
+        if not isinstance(pcre2_callout_block, _cy.PCRE2CalloutBlock):
+            raise ValueError(
+                "PCRE2 callout block data must be of type `_cy.PCRE2CalloutBlock`. It is not"
+                "recommended to instantiate `CalloutBlock` objects directly."
+            )
+        self._pcre2_callout_block = pcre2_callout_block
+        self.re = re
+        self.string = string
+
+    def __repr__(self):
+        return (
+            f"<{self.__class__.__module__}.{self.__class__.__qualname__} object; "
+            f"value={self.value}, span={self.span()}, match={repr(self.group())}>"
+        )
+
+    @property
+    @lru_cache(1)
+    def value(self):
+        return _cy.callout_block_get_value(self._pcre2_callout_block)
+
+    def _groupguard(self, group):
+        if isinstance(group, int):
+            if not 0 <= group <= self.re.groups:
+                raise IndexError("No such group")
+            group_number = group
+        elif isinstance(group, str):
+            if group not in self.re.groupindex:
+                raise IndexError("no such group")
+            group_number = self.re.groupindex[group]
+        elif hasattr(group, "__index__"):
+            group_number = int(group.__index__())
+        else:
+            raise IndexError("No such group")
+        return group_number
+
+    def span(self, group=0):
+        """
+        Return the start and end of `group` as the tuple `(start, end)`.
+
+        If `group` did not contribute to the match, `(-1, -1)` is returned.
+        """
+        group_number = self._groupguard(group)
+        return _cy.callout_block_substring_span_bynumber(
+            self._pcre2_callout_block, self.string, group_number
+        )
+
+    def __getitem__(self, group):
+        group_number = self._groupguard(group)
+        return _cy.callout_block_substring_bynumber(
+            self._pcre2_callout_block, self.string, group_number
+        )
+
+    def group(self, *groups):
+        """
+        Returns one or more subgroups of the callout block.
+
+        If there is a single argument, the result is a single string. If there are multiple
+        arguments, the result is a tuple with one item per argument. Without arguments, the whole
+        string matched in the callout block is returned.
+        """
+        if not groups:
+            groups = (0,)
+        items = map(self.__getitem__, groups)
+        return next(items) if len(groups) == 1 else tuple(items)
+
+    def groups(self, default=None):
+        """
+        Return a tuple containing all the subgroups of the callout block.
         """
         items = []
         for group in range(1, self.re.groups + 1):

--- a/src/pcre2/_cy.pyx
+++ b/src/pcre2/_cy.pyx
@@ -1,15 +1,18 @@
 # -*- coding:utf-8 -*-
 # cython: profile=True
 
+from cython cimport freelist
+from cython.operator cimport dereference
 from libc.stdint cimport uint8_t, uint32_t
 from libc.stdlib cimport malloc, free
 from libc.string cimport strlen
+from cpython cimport Py_INCREF, Py_DECREF, PyObject
 from cpython.unicode cimport PyUnicode_Check, PyUnicode_AsUTF8AndSize
 from cpython.bytes cimport PyBytes_Check, PyBytes_AsStringAndSize
 
 from _libpcre2 cimport *
 
-from enum import IntFlag
+from enum import IntFlag, IntEnum
 
 
 __libpcre2_version__ = f"{PCRE2_MAJOR}.{PCRE2_MINOR}"
@@ -41,6 +44,7 @@ cdef class PCRE2Code:
             pcre2_code_free(self.ptr)
 
 
+@freelist(8)
 cdef class PCRE2MatchData:
     cdef pcre2_match_data_t *ptr
 
@@ -59,6 +63,71 @@ cdef class PCRE2MatchData:
     def __dealloc__(self):
         if self.ptr is not NULL:
             pcre2_match_data_free(self.ptr)
+
+
+cdef class PCRE2MatchContext:
+    cdef pcre2_match_context_t *ptr
+    cdef object _callout_function  # Keep a reference to the wrapped callout function
+
+    @staticmethod
+    cdef PCRE2MatchContext from_ptr(pcre2_match_context_t *ptr, object callout_function):
+        """ Ownership of pointer is always taken by the new instance """
+        cdef PCRE2MatchContext match_context
+        match_context = PCRE2MatchContext.__new__(PCRE2MatchContext)
+        match_context.ptr = ptr
+        match_context._callout_function = callout_function
+        return match_context
+
+    def __init__(self, *args, **kwargs):
+        # Prevent accidental instantiation from normal Python code
+        raise TypeError(f"Cannot create 'PCRE2MatchContext' instances")
+
+    def __dealloc__(self):
+        if self.ptr is not NULL:
+            pcre2_match_context_free(self.ptr)
+
+
+@freelist(8)
+cdef class PCRE2CalloutBlock:
+    cdef pcre2_callout_block_t *ptr
+
+    @staticmethod
+    cdef PCRE2CalloutBlock copy_from_ptr(pcre2_callout_block_t *ptr):
+        """
+        Pointer content is copied into new memory location! Original pointer must be managed
+        independently. This is typically performed by PCRE2 as callout blocks are ephemeral
+        """
+        cdef:
+            PCRE2CalloutBlock callout_block
+            pcre2_callout_block_t *copy_ptr
+            size_t *copy_offset_vector
+            int idx
+
+        # Allocate memory for copied results
+        copy_ptr = <pcre2_callout_block_t *>malloc(sizeof(pcre2_callout_block_t))
+        copy_offset_vector = <size_t *>malloc(2 * ptr[0].capture_top * sizeof(size_t))
+
+        # First copy over contents of callout block as is
+        copy_ptr[0] = ptr[0]
+
+        # Now override the offset vector with a copied version
+        for idx in range(2 * ptr[0].capture_top):
+            copy_offset_vector[idx] = ptr[0].offset_vector[idx]
+        copy_ptr[0].offset_vector = copy_offset_vector
+
+        callout_block = PCRE2CalloutBlock.__new__(PCRE2CalloutBlock)
+        callout_block.ptr = copy_ptr
+        return callout_block
+
+    def __init__(self, *args, **kwargs):
+        # Prevent accidental instantiation from normal Python code
+        raise TypeError(f"Cannot create 'PCRE2CalloutBlock' instances")
+
+    def __dealloc__(self):
+        if self.ptr is not NULL:
+            if self.ptr[0].offset_vector is not NULL:
+                free(self.ptr[0].offset_vector)
+            free(self.ptr)
 
 
 # ============================================================================
@@ -182,6 +251,10 @@ class CompileOption(IntFlag):
     # be disabled by the `ASCII` flag in the Python wrapper
     UCP = PCRE2_UCP
 
+    NO_AUTO_POSSESS = PCRE2_NO_AUTO_POSSESS
+    NO_START_OPTIMIZE = PCRE2_NO_START_OPTIMIZE
+    NO_DOTSTAR_ANCHOR = PCRE2_NO_DOTSTAR_ANCHOR
+
 
 def compile(object pattern, uint32_t options = 0, disabled_options = 0):
     cdef:
@@ -275,7 +348,9 @@ def pattern_name_dict(PCRE2Code code not None):
     return name_dict
 
 
-def substring_span_bynumber(PCRE2MatchData match_data not None, object subject, size_t number):
+def match_substring_span_bynumber(
+    PCRE2MatchData match_data not None, object subject, size_t number
+):
     cdef:
         size_t *ovector
         uint8_t *subj_sptr
@@ -303,7 +378,7 @@ def substring_span_bynumber(PCRE2MatchData match_data not None, object subject, 
     return (-1, -1)
 
 
-def substring_bynumber(PCRE2MatchData match_data not None, object subject, size_t number):
+def match_substring_bynumber(PCRE2MatchData match_data not None, object subject, size_t number):
     cdef:
         size_t *ovector
         uint8_t *subj_sptr
@@ -329,6 +404,137 @@ def substring_bynumber(PCRE2MatchData match_data not None, object subject, size_
     if PyUnicode_Check(subject):
         res_obj = res_obj.decode("UTF-8")
     return res_obj
+
+
+def callout_block_substring_span_bynumber(
+    PCRE2CalloutBlock callout_block not None, object subject, size_t number
+):
+    cdef:
+        uint8_t *subj_sptr
+        size_t subj_size
+        size_t start
+        size_t end
+
+    # Get views into object memory
+    subj_sptr, subj_size = as_sptr_and_size(subject)
+
+    # Only perform offset lookup if group has been set
+    if number < callout_block.ptr[0].capture_top:
+        # Use the in progress match up until the callout as the "matched" substring
+        if number == 0:
+            start = callout_block.ptr[0].start_match
+            end = callout_block.ptr[0].current_position
+        # Otherwise look up the group offsets directly
+        else:
+            start = callout_block.ptr[0].offset_vector[2 * number]
+            end = callout_block.ptr[0].offset_vector[2 * number + 1]
+
+        if start != PCRE2_UNSET:
+            if PyUnicode_Check(subject):
+                start = idx_byte_to_char(subj_sptr, start)
+                end = idx_byte_to_char(subj_sptr, end)
+            return (start, end)
+
+    return (-1, -1)
+
+
+def callout_block_substring_bynumber(
+    PCRE2CalloutBlock callout_block not None, object subject, size_t number
+):
+    cdef:
+        uint8_t *subj_sptr
+        size_t subj_size
+        size_t start
+        size_t end
+
+    # Get views into object memory
+    subj_sptr, subj_size = as_sptr_and_size(subject)
+
+    # Only perform offset lookup if group has been set
+    if number < callout_block.ptr[0].capture_top:
+        # Use the in progress match up until the callout as the "matched" substring
+        if number == 0:
+            start = callout_block.ptr[0].start_match
+            end = callout_block.ptr[0].current_position
+        # Otherwise look up the group offsets directly
+        else:
+            start = callout_block.ptr[0].offset_vector[2 * number]
+            end = callout_block.ptr[0].offset_vector[2 * number + 1]
+
+        if start != PCRE2_UNSET:
+            res_obj = bytes(subj_sptr[start:end])
+            if PyUnicode_Check(subject):
+                res_obj = res_obj.decode("UTF-8")
+            return res_obj
+    return None
+
+
+def callout_block_get_value(PCRE2CalloutBlock callout_block not None):
+    if callout_block.ptr[0].callout_string is NULL:
+        callout_value = <int>callout_block.ptr[0].callout_number
+    else:
+        # Always decode callout strings into Python string types
+        callout_value = bytes(
+            callout_block.ptr[0].callout_string[:callout_block.ptr[0].callout_string_length]
+        )
+        callout_value = callout_value.decode("UTF-8")
+    return callout_value
+
+# ============================================================================
+#                                                            Callout functions
+
+class CalloutFunctionReturn(IntEnum):
+    PASS = 0
+    FAIL = 1
+    ABORT = -1
+
+
+cdef int callout_function_wrapper(
+    pcre2_callout_block_t *callout_block_ptr, void *callout_function_ptr
+) except *:
+    cdef:
+        PCRE2CalloutBlock callout_block
+        size_t group_number
+        object group
+        object groups
+        object callout
+        object callout_result
+        int32_t res
+
+    # Copy callout block data into Cython extension type
+    callout_block = PCRE2CalloutBlock.copy_from_ptr(callout_block_ptr)
+
+    # Convert the function pointer back to a Python object and call
+    callout_result = (<object>callout_function_ptr)(callout_block)
+    if callout_result is None:
+        callout_result = CalloutFunctionReturn.PASS
+
+    # Print nicer message if invalid return given
+    if not any(x.value == callout_result for x in CalloutFunctionReturn):
+        raise ValueError(
+            "Invalid callout function result, "
+            f"must be one of: {', '.join(f'{x.name}={x.value}' for x in CalloutFunctionReturn)}"
+        )
+    res = CalloutFunctionReturn(callout_result)
+    return res
+
+
+def create_match_context(object callout_function=None):
+    cdef:
+        pcre2_match_context_t *match_context_ptr
+        PyObject *callout_function_ptr
+
+    # Aquire pointer to empty match context
+    match_context_ptr = pcre2_match_context_create(NULL)
+    if match_context_ptr is NULL:
+        raise MemoryError
+
+    # Set the callout function if provided
+    if callout_function:
+        callout_function_ptr = <PyObject *>callout_function
+        pcre2_set_callout(match_context_ptr, callout_function_wrapper, callout_function_ptr)
+
+    return PCRE2MatchContext.from_ptr(match_context_ptr, callout_function)
 
 
 # ============================================================================
@@ -360,6 +566,7 @@ cdef PCRE2MatchData _match(
     size_t byte_length,
     size_t byte_offset,
     uint32_t options,
+    PCRE2MatchContext match_context,
 ) except *:
     cdef:
         pcre2_match_data_t *match_data_ptr
@@ -371,7 +578,9 @@ cdef PCRE2MatchData _match(
         raise MemoryError
 
     # Attempt match of pattern onto the subject
-    rc = _pcre2_match(code.ptr, subj_sptr, byte_length, byte_offset, options, match_data_ptr, NULL)
+    rc = _pcre2_match(
+        code.ptr, subj_sptr, byte_length, byte_offset, options, match_data_ptr, match_context.ptr
+    )
     if rc == PCRE2_ERROR_NOMATCH:
         return None
     raise_from_rc(rc)
@@ -383,6 +592,7 @@ def match(
     object subject,
     size_t length, # length & offset in logical (index) units
     size_t offset,
+    PCRE2MatchContext match_context not None,
     uint32_t options = 0,
 ):
     cdef:
@@ -412,7 +622,7 @@ def match(
             subj_size if offset == len(subject) else idx_char_to_byte(subj_sptr, subj_size, offset)
         )
 
-    return _match(code, subj_sptr, length, offset, options), offset, options
+    return _match(code, subj_sptr, length, offset, options, match_context), offset, options
 
 
 def match_generator(
@@ -420,6 +630,7 @@ def match_generator(
     object subject,
     size_t length, # length & offset in logical (index) units
     size_t offset,
+    PCRE2MatchContext match_context not None,
 ):
     cdef:
         uint32_t starting_options = 0
@@ -455,7 +666,9 @@ def match_generator(
     while byte_offset <= byte_length:
         match_options = starting_options | state_options
         match_byte_offset = byte_offset
-        match_data = _match(code, subj_sptr, byte_length, match_byte_offset, match_options)
+        match_data = _match(
+            code, subj_sptr, byte_length, match_byte_offset, match_options, match_context
+        )
         if not match_data:
             break
 

--- a/src/pcre2/_libpcre2.pxd
+++ b/src/pcre2/_libpcre2.pxd
@@ -7,6 +7,8 @@ cdef extern from "pcre2.h":
     cdef unsigned int PCRE2_MAJOR
     cdef unsigned int PCRE2_MINOR
 
+    cdef unsigned int PCRE2_UNSET
+
     # The following option bits can be passed to pcre2_compile(),
     # pcre2_match(), or pcre2_dfa_match(). PCRE2_NO_UTF_CHECK affects only the
     # function to which it is passed. Put these bits at the most significant
@@ -344,6 +346,9 @@ cdef extern from "pcre2.h":
     cdef int PCRE2_CONFIG_COMPILED_WIDTHS
     cdef int PCRE2_CONFIG_TABLES_LENGTH
 
+    # Basic string definition. Note that this assumes PCRE2 in compiled to
+    # support 8-bit strings.
+    ctypedef const uint8_t *pcre2_sptr_t "PCRE2_SPTR"
 
     # Opaque handles for PCRE2 defined structs.
     ctypedef struct pcre2_code_t "pcre2_code":
@@ -356,10 +361,23 @@ cdef extern from "pcre2.h":
         pass
     ctypedef struct pcre2_match_context_t "pcre2_match_context":
         pass
-
-    # Basic string definition. Note that this assumes PCRE2 in compiled to
-    # support 8-bit strings.
-    ctypedef const uint8_t *pcre2_sptr_t "PCRE2_SPTR"
+    ctypedef struct pcre2_callout_block_t "pcre2_callout_block":
+        uint32_t     version
+        uint32_t     callout_number
+        uint32_t     capture_top
+        uint32_t     capture_last
+        uint32_t     callout_flags
+        size_t      *offset_vector
+        pcre2_sptr_t mark
+        pcre2_sptr_t subject
+        size_t       subject_length
+        size_t       start_match
+        size_t       current_position
+        size_t       pattern_position
+        size_t       next_item_length
+        size_t       callout_string_offset
+        size_t       callout_string_length
+        pcre2_sptr_t callout_string
 
     # Error handling functions.
     int pcre2_get_error_message(
@@ -396,6 +414,17 @@ cdef extern from "pcre2.h":
     int pcre2_substring_number_from_name(
         const pcre2_code_t *code,
         pcre2_sptr_t name
+    )
+
+    # Match context
+    pcre2_match_context_t * pcre2_match_context_create(pcre2_general_context_t *gcontext)
+
+    void pcre2_match_context_free(pcre2_match_context_t *mcontext)
+
+    int pcre2_set_callout(
+        pcre2_match_context_t *mcontext,
+        int (*callout_function)(pcre2_callout_block_t *, void *) except *,
+        void *callout_data
     )
     
     # Matching and match data functions.

--- a/tests/test_callouts.py
+++ b/tests/test_callouts.py
@@ -1,0 +1,76 @@
+import pytest
+import pcre2
+import re
+
+
+# All tests should match successfully.
+test_data_noop_callout_match_bounds = [
+    (b".*", "aba•ba••ba•••b".encode(), 0, 0, None, 0, 0, 26),
+    (".*", "aba•ba••ba•••b", 0, 0, None, 0, 0, 14),
+    (r"\w+", "b•", 0, 0, None, 0, 0, 1),
+    (r"\w+", "b•", 0, None, None, 0, 0, 1),
+    (r"\w+", "•b", 0, 1, None, 0, 1, 2),
+    (r"\w+", "•bc", 0, 2, None, 0, 2, 3),
+    (r"\w+", "•bc", 0, 1, 2, 0, 1, 2),
+]
+
+
+@pytest.mark.parametrize(
+    "pattern,subject,flags,pos,endpos,group,start,end", test_data_noop_callout_match_bounds
+)
+def test_noop_callout_match_bounds(pattern, subject, flags, pos, endpos, group, start, end):
+    def noop_callout(callout_block):
+        callout_block[0]
+        callout_block.span()
+        callout_block.group(0)
+        callout_block.groups()
+        callout_block.groupdict()
+        return pcre2.CalloutReturn.PASS
+
+    p = pcre2.compile(pattern, flags=flags, callout=noop_callout)
+    kwargs = {}
+    if endpos is not None:
+        kwargs["endpos"] = endpos
+    if pos is not None:
+        kwargs["pos"] = pos
+    m = p.match(subject, **kwargs)
+    assert (m.start(group), m.end(group)) == (start, end)
+    if endpos is not None:
+        assert m.endpos == endpos
+    if pos is not None:
+        assert m.pos == pos
+
+
+test_data_callout_substring_count = [
+    ("aba•ba••ba•••b".encode(), pcre2.O0),
+    ("aba•ba••ba•••b", pcre2.O0),
+    ("b•", pcre2.O0),
+    ("b•", pcre2.O0),
+    ("•b", pcre2.O0),
+    ("•bc", pcre2.O0),
+    ("•bc", pcre2.O0),
+    ("•bc", pcre2.NOFLAG),
+]
+
+
+@pytest.mark.parametrize("subject,flags", test_data_callout_substring_count)
+def test_callout_substring_count(subject, flags):
+    pattern = r".+(?C'')(*FAIL)" if isinstance(subject, str) else rb".+(?C'')(*FAIL)"
+
+    substrings = []
+
+    def substring_count_callout(callout_block):
+        substrings.append(callout_block[0])
+
+    pcre2.search(pattern, subject, flags=pcre2.O0, callout=substring_count_callout)
+    assert len(substrings) == len(subject) * (len(subject) + 1) / 2
+
+
+def test_callout_block_persist():
+    callout_blocks = []
+
+    def persist_blocks_callout(callout_block):
+        callout_blocks.append(callout_block)
+
+    pcre2.search(r".+(?C'')(*FAIL)", "•bc", flags=pcre2.O0, callout=persist_blocks_callout)
+    assert [block[0] for block in callout_blocks] == ["•bc", "•b", "•", "bc", "b", "c"]

--- a/tests/test_re_compatibility.py
+++ b/tests/test_re_compatibility.py
@@ -178,7 +178,7 @@ def test_qualified_re_sub():
     with pytest.raises(TypeError, match=r"sub\(\) got multiple values for argument 'flags'"):
         re.sub("a", "b", "aaaaa", 1, 0, flags=0)
     with pytest.raises(
-        TypeError, match=r"sub\(\) takes from 3 to 6 positional arguments but 7 were given"
+        TypeError, match=r"sub\(\) takes from 3 to 5 positional arguments but 7 were given"
     ):
         re.sub("a", "b", "aaaaa", 1, 0, False, 0)
 


### PR DESCRIPTION
Add preliminary support for PCRE2 callouts, raised in https://github.com/grtetrault/pcre2.py/issues/10. Functionality includes:
- The ability to a Python function as a callout to PCRE2 matches and substitutions.
- Enums for the return values of callout functions (i.e., pass, fail, abort) - unspecified returns default to pass.
- A `CalloutBlock` Python object that provides a `Match`-like interface to callout blocks.
- Pattern compilation flag to disable optimizations - this is sometimes required to get callouts to behave as expected.

Notes on the limitations of this change:
- Substitute callouts do not use the functionality provided by `pcre2_set_substitute_callout`. Instead, substitution is done by iterative matches (the same as if you provide a callable replacement), and callouts operate as normal on these matches.
- Not all callout block fields are exposed directly (e.g., `capture_last`).